### PR TITLE
Preprocessing for html files

### DIFF
--- a/html_snip.html
+++ b/html_snip.html
@@ -1,0 +1,26 @@
+<div _ngcontent-tqm-c11="" class="content-text" style='font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, sans-serif; font-size: 100%; --active-text-color:rgba(0, 0, 0, 1); --active-text-background-color:rgba(201, 230, 255, 1); --inactive-text-color:rgba(0, 0, 0, 1); --content-background-color:rgba(255, 255, 255, 1);'><div class="page-front" id="page-i" title="i"></div>
+<h1 class="active" id="h1_1"><a href="https://spilari.hbs.is/embedded/s001.smil#h1_1">Samfélagshjúkrun</a></h1>
+<p id="hix06058"><b>BRÁÐABIRGÐA HLJÓÐBÓK</b></p>
+<p id="hix00001"><strong><span class="sentence" id="jrtw_0001">Aðalbjörg Stefanía Helgadóttir</span></strong></p>
+<p id="hix00002"><strong><span class="sentence" id="jrtw_0002">Iðnú, Reykjavík 2021</span></strong></p>
+<p id="hix00003"> </p>
+<p id="hix00004"><span class="sentence" id="adqw_0001">Þessi útgáfa tekur 20 klukkustundir og 15 mínútur í afspilun. </span><strong> </strong></p>
+<p id="hix00005"><span class="sentence" id="adqw_0003">Lesari: Talgervillinn Dóra</span></p>
+<h1 id="h1_2"><a href="https://spilari.hbs.is/embedded/s002.smil#h1_2">Texti á bókarkápu</a></h1>
+<p id="hix00006"><span class="sentence" id="uiid_0003">Samfélagshjúkrun er kennslubók eftir Aðalbjörgu Stefaníu Helgadóttur. </span><span class="sentence" id="uiid_0004">Bókin byggist á reynslu og þekkingu á hjúkrun í íslensku samfélagi og er ætluð til kennslu á 3. </span><span class="sentence" id="uiid_0005">hæfniþrepi sjúkraliðanáms. </span><span class="sentence" id="uiid_0006">Hún miðlar jafnframt þekkingu og skilningi á samfélagshjúkrun almennt, með sérstakri áherslu á geðhjúkrun. </span><span class="sentence" id="uiid_0007">Efninu er skipt í þrjá hluta þar sem fjallað er um samfélagið, fjölskylduna og geðheilsu í víðu samhengi. </span></p>
+<h1 id="h1_3"><a href="https://spilari.hbs.is/embedded/s003.smil#h1_3">Notkunarskilmálar</a></h1>
+<p id="hix00007"><span class="sentence" id="hqhv_0008">Hljóðbókasafn Íslands þjónar samkvæmt lögum eingöngu þeim sem ekki geta nýtt sér prentað letur. </span></p>
+<p id="hix00008"><span class="sentence" id="hqhv_0009">Þessi bók er gerð aðgengileg árið 2021 í samræmi við ákvæði 19. </span><span class="sentence" id="hqhv_0010">greinar höfundalaga og samning Mennta- og menningarmálaráðuneytis og Rithöfundasambands Íslands. </span></p>
+<p id="hix00009"><span class="sentence" id="hqhv_0011">Eintak þetta er eign Hljóðbókasafns Íslands og það má ekki afrita. </span></p>
+<p id="hix00010"><span class="sentence" id="hqhv_0012">Útlán eru merkt lánþegum og bækur safnsins eru eingöngu fyrir skráða lánþega. </span><span class="sentence" id="hqhv_0013">Safnið áskilur sér rétt til að loka aðgangi verði misnotkunar vart. </span></p>
+<p id="hix00011"><span class="sentence" id="hqhv_0014">Athugið að geisladiskum ber að farga að notkun lokinni. </span></p>
+<h1 id="h1_4"><a href="https://spilari.hbs.is/embedded/s004.smil#h1_4">Um útgáfu þessarar bókar</a></h1>
+<p id="hix00012"><span class="sentence" id="cbtl_0015">Bókarnúmer:</span><span class="sentence" id="cbtl_0016"> 29031</span></p>
+<p id="hix00013"><span class="sentence" id="cbtl_0019">Útgáfa:</span><span class="sentence" id="cbtl_0020"> © Aðalbjörg Stefanía Helgadóttir, Iðnú 2021</span></p>
+<p class="isbn" id="hix00014"><span class="sentence" id="cbtl_0021">I S B N:</span><span class="sentence" id="cbtl_0022"> 978 997 967 4887</span></p>
+<div class="page-normal" id="page-1" title="1"></div>
+<h1 id="h1_6"><a href="https://spilari.hbs.is/embedded/s005.smil#h1_6">Efnisyfirlit</a></h1>
+<ol class="list-style-type-none" style="LIST-STYLE-TYPE: none">
+<li id="hix00015"><span class="sentence" id="dhls_0024"><a href="https://spilari.hbs.is/embedded/006_Form_li.html#h1_7" shape="rect"><span class="lic">Formáli</span><span class="lic"> 5</span></a></span></li>
+<li id="hix00016">
+<span class="sentence" id="dhls_0025"><a href="https://spilari.hbs.is/embedded/007_Samf_lagi.html#h1_8" shape="rect"><span class="lic"><strong>Samfélagið</strong></span><span class="lic"> 9</span></a></span>

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -7,7 +7,7 @@ def test_default_clean():
     assert clean.clean("we strip all 😎 emojis 😎") == "ve strip all emojis"
     assert clean.clean("📌 red pin") == "red pin"
     assert clean.clean("ß Ø") == "ss Ö"
-    assert clean.clean("<p> HTML tög </p>") == "HTML tög"
+    assert clean.clean("<p> HTML tög </p>") == "p HTML tög p"
     assert clean.clean("raki (e. humidity)") == "raki , e. humidity ,"
     assert clean.clean("123") == "123"
 
@@ -27,13 +27,6 @@ def test_preserve_characters():
     assert clean.clean("Barizt hefur Zorro, margoft án hanzka", char_to_preserve=['Zorro']) == "Barist hefur Zorro, margoft án hanska"
     assert clean.clean("(Zwoozh) er ekki ízlenzkt orð.", char_to_preserve=['Zwoozh']) == ", Zwoozh , er ekki íslenskt orð."
     
-def test_clean_html_text():
-    ## Audiobooks fall under this category
-    # TODO: html clean feature will enable more complex html cleaning. Currently testing naked html text is possible
-    assert clean.clean("<p> einskonar kerfi (e. system) </p>", clean_audiobook=True) == "einskonar kerfi <en> system </en> ."
-    assert clean.clean("<p> (1920. Brynjar), samhengi í lífinu (e. sense of coherence). </p>") == ", 1920. Brynjar , , samhengi í lífinu , e. sense of koherenke , ."
-    assert clean.clean("<p> (1920. Brynjar), samhengi í lífinu (e. sense of coherence). </p>", clean_audiobook=True) == ", 1920. Brynjar , , samhengi í lífinu <en> sense of coherence </en>. ."
-
 def test_clean_punctuation():
     # replace punct set
     assert clean.clean(",.:!?", punct_set=[',','.']) == ",." 

--- a/text_cleaner/clean_html.py
+++ b/text_cleaner/clean_html.py
@@ -1,0 +1,130 @@
+
+import argparse
+import re
+from bs4 import BeautifulSoup as beautiful_soup
+from text_cleaner import constants
+
+
+def remove_whitespace_before_punctuation(text):
+    # the following regex demarks a string with 1 or more 
+    # whitespaces followed by a punctuation mark
+    return re.sub(r'\s+([,.?!])', r'\1', text)
+
+
+def remove_consecutive_punct_marks(soup):
+    # the following regex demarks a string with 1 punctuation 
+    # mark followed by 1 or more punctuation marks
+    return re.sub(r'([,.:;?!])[,.:;?!]+', r'\1', soup)
+
+
+# TODO: Incomplete.
+# Currently this method only works for tables with the same amount of rows & columns
+# Also the headers are currently appended to all rows (even those before), this will become
+# problematic if a table with that description is in the html document.
+def clean_html_tables(soup):
+    """
+    Organizes text in tables by prepending a header for each cell in it's 
+    column and finally removes the rows containing only headers.
+    """
+    tables = soup.find_all('table')
+
+    for table in tables:
+        table_row = table.find_all('tr')
+        # used by each cell to reference it's header content
+        table_headers = table.find_all('th')
+
+        for _, row, in enumerate(table_row):
+            table_cell = row.find_all('td') # list of cells for current row
+            for idx2, cell in enumerate(table_cell):
+                cell = cell.insert_before(table_headers[idx2].get_text())
+
+        # remove headers after they've been prepended to each cell in their shared table
+        for th in table_headers:
+            th.decompose()
+    return soup
+
+
+def append_punctuation_to_tag_content(text, html_tag_to_punctuation_mark):    
+    """
+    Appends characters to html tags found in input dictionary to beautifulsoup element tag (text). 
+    """
+    print(type(text))
+    for tag in html_tag_to_punctuation_mark:
+        for text_within_tag in text.find_all(tag):
+            text_within_tag.append(html_tag_to_punctuation_mark[tag])
+    return text
+
+
+def extract_html_from_file(html_doc, extract_from_div):
+    html_doc_content = open(html_doc)
+    soup = beautiful_soup(html_doc_content.read(), features='html.parser')
+    soup = soup.find("div", extract_from_div)
+
+    return soup
+
+
+def clean_html(
+    html_doc,
+    replace_html_closing_tag_with={},
+    content_parent_div={},
+    write_to_file='',
+):
+    """
+    Preprocess html document input for text cleaning by parsing text content 
+    specified by input, by removing and replacing html tags based on dictionary input.
+    
+    Args:
+        html_doc                        : html document to extract from
+        replace_html_closing_tag_with   : dictionary of html tags to be convert 
+        write_to_file                   : name of output file
+        content_parent_div              : the parent div of all the content to be cleaned
+
+    Returns:
+        str: the input html document stripped of html tags
+    """
+
+
+    # WIP - Read description for method
+    # soup = clean_html_tables(soup)
+
+    html_soup = extract_html_from_file(html_doc, extract_from_div=content_parent_div)
+
+    html_soup = append_punctuation_to_tag_content(html_soup, replace_html_closing_tag_with)
+    text = html_soup.get_text()
+
+
+    text = remove_whitespace_before_punctuation(text)
+    text = remove_consecutive_punct_marks(text)
+
+    if write_to_file:
+        f = open(write_to_file, "a")    
+        f.write(str(text))
+        f.close()
+
+    return text
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('file', type=argparse.FileType('r'), help="html file to be extracted")
+    args = parser.parse_args()
+    
+    return args
+
+
+def main():
+    dictionary = {}
+    for element in constants.HTML_ELEMENTS: # convenient while developing this html cleaner
+        dictionary[element] = '. '
+
+    print(
+        clean_html(
+            html_doc='html_snip.html',
+            replace_html_closing_tag_with=dictionary,
+            content_parent_div={"class": "content-text"},
+            write_to_file='cleaned_html_text.txt'
+        ))
+
+
+if __name__ == '__main__':
+    main()

--- a/text_cleaner/constants.py
+++ b/text_cleaner/constants.py
@@ -1,10 +1,7 @@
 character_alphabet = ['a', 'á', 'b', 'd', 'ð', 'e', 'é', 'f', 'g', 'h', 'i', 'í', 'j', 'k', 'l', 'm',
                       'n', 'o', 'ó', 'p', 'r', 's', 't', 'u', 'ú', 'v', 'y', 'ý', 'þ', 'æ', 'ö', 'x']
 
-punctuation_marks = ['.',',',':','!','?']
+punctuation_marks = {'.',',',':','!','?'}
 
-HTML_TAGS = ['<span>','<ul>','<ol>','<li>','<dl>','<dt>','<dd>','<table>','<tr>','<td>',
-             '<h1>', '<h2>','<h3>','<h4>', '<h5>','<h6>','<p>','<br>','<hr>',]
-
-HTML_CLOSING_TAGS = ['</span>','</ul>','</ol>','</li>','</dl>','</dt>','</dd>','</table>','</tr>','</td>',
-                     '</h1>','</h2>','</h3>','</h4>','</h5>','</h6>','</p>','</br>','</hr>',]
+HTML_ELEMENTS = {'ul','ol','li','dl','dt','dd','table','tr',
+                 'td','h1','h2','h3','h4','h5','h6','p','br','hr'}


### PR DESCRIPTION
Preprocessing feature for html files. 

Introduces a method named `clean_html()` that parses an html documents and prepares the text in that document to be cleaned with the text cleaner. 
This feature introduces decoupling of the html cleaning process from the cleaning done by the `clean()` method. This helps by simplifying the cleaning process which could easily have overlapping rules when setting many arguments.

Currently the feature breaks when processing text from tables if the table dimensions aren't the same throughout the table. It was decided that this was sufficient for the time being and will be addressed in the near future.