### PR TITLE
Clean html table fix

### DIFF
--- a/text_cleaner/clean.py
+++ b/text_cleaner/clean.py
@@ -57,8 +57,8 @@ def should_delete(char) -> str:
 
 
 def clean_foreign_text_occurrence(token) -> str:
-    token = token.replace("(e.", "<en>") # Subject to change
-    token = token.replace(")", " </en>")
+    token = token.replace("(e.", '<lang xml:lang="en-GB">') # SSML standard 
+    token = token.replace(")", " </lang>")
 
     return token + ' '
 


### PR DESCRIPTION
Applying a fix for `clean_html.py` when it comes to sorting out text in tables.

Also changing the "foreign word" tag in the `clean.py` file from <en> to <lang xml:lang="en-GB"> to conform with SSML standard. 