### PR TITLE
fix preserve_strings checks

### DIFF
--- a/text_cleaner/clean.py
+++ b/text_cleaner/clean.py
@@ -62,6 +62,7 @@ class TextCleaner:
         :param delete_labelled_translations: if True, we delete text/tokens labelled as foreign, default is False
 
         """
+
         # since we might alter replacement_dictionary, make a copy of the parameter dictionary
         self.replacement_dictionary = replacement_dict.copy()
         self.post_dict_lookup = post_dict
@@ -147,7 +148,7 @@ class TextCleaner:
             # TODO: only covers english text atm and assumes it's prefixed by "(e." as is by convention
             if token.startswith(EN_LABEL):
                 cleaned_text += self.clean_labelled_translation(token)
-            elif token.strip('r'+COMMON_PUNCT) in self.preserve_strings:
+            elif token in self.preserve_strings or token.strip('r'+COMMON_PUNCT) in self.preserve_strings:
                 # TODO: is this defined somewhere? Why '"()'?
                 token = re.sub(r'["()]', ' , ', token)
                 cleaned_text += token + ' '
@@ -210,7 +211,7 @@ class TextCleaner:
             repl = self.replacement_dictionary[char] if char in self.replacement_dictionary else ''
             if repl:
                 token = token.replace(char, repl)
-            elif char in self.preserve_strings or char.isdigit():
+            elif char.isdigit():
                 continue
             elif char in emoji_dictionary.EMOJI_PATTERN:
                 # We have already taken care of emojis


### PR DESCRIPTION
Two changes regarding preserve_strings checks:

- preserve_strings both with and without punctuation, since preserved_strings themselves can include punctuation (before: only stripped of punctuation was checked)
- don't check for preserved strings in validate_chars, we already check if the whole token is in preserved_strings, all valid characters (=characters to preserve) should be in the alphabet list. Checking for preserved_strings token-wise causes all single letters contained in the dictionary or abbr. dict to be let through, e.g. 'c' in 'cavity' would not be replaced since 'c' is an entry in the dictionary.